### PR TITLE
レイアウト、挙動の細かい修正

### DIFF
--- a/app/src/main/java/biz/moapp/english_dictionary/ui/base/BaseScreen.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/base/BaseScreen.kt
@@ -47,7 +47,6 @@ fun BaseScreen(topScreenViewModel: TopScreenViewModel, searchResultViewModel: Se
             composable(route = "${Nav.SearchResultScreen.name}/{keyWord}",
                 arguments = listOf(navArgument("keyWord") { type = NavType.StringType })
             ) {backStackEntry ->
-                topScreenViewModel.initializeValues()
                 val keyWord = backStackEntry.arguments?.getString("keyWord")
                 SearchResultScreen(Modifier.padding(innerPadding),keyWord, searchResultViewModel,)
             }

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/base/BaseScreen.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/base/BaseScreen.kt
@@ -23,7 +23,7 @@ import biz.moapp.english_dictionary.ui.top.TopScreenViewModel
 @Composable
 fun BaseScreen(topScreenViewModel: TopScreenViewModel, searchResultViewModel: SearchResultViewModel,) {
     val navController = rememberNavController()
-    Scaffold(modifier = Modifier.fillMaxSize(), topBar = { TopBar(navController) }, bottomBar = { BottomBar()}){  innerPadding ->
+    Scaffold(modifier = Modifier.fillMaxSize(), topBar = { TopBar(navController) }, /*bottomBar = { BottomBar()}*/){  innerPadding ->
         NavHost(
             navController = navController, startDestination = Nav.TopScreen.name,
             enterTransition = {

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/parts_compose/tab_content/SynonymsTab.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/parts_compose/tab_content/SynonymsTab.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.HorizontalDivider
@@ -15,25 +16,32 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import biz.moapp.english_dictionary.R
 import biz.moapp.english_dictionary.data.json_row.Synonym
+import biz.moapp.english_dictionary.ui.search_result.parts_compose.SoundIcon
 
 @Composable
-fun SynonymsTab(modifier: Modifier = Modifier, data: List<Synonym>){
+fun SynonymsTab(modifier: Modifier = Modifier, synonyms: List<Synonym>){
     Column( modifier = Modifier.fillMaxSize(),
         verticalArrangement = Arrangement.Top,
         horizontalAlignment = Alignment.Start) {
-        data.forEach { _ ->
+        synonyms.forEach { _ ->
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(4.dp),
                 horizontalAlignment = Alignment.Start
             ) {
-               items(data){
+               items(synonyms){ synonym ->
                    Spacer(modifier = Modifier.height(8.dp))
                    Row {
-                       Text(text = "英語：${it.word}, ")
-                       Text(text = "日本語：${it.japaneseMeaning}")
+                       SoundIcon(word = synonym.word)
+                       Column(modifier = Modifier.padding(top = 2.dp)) {
+                           Text(text = stringResource(R.string.synonyms_eng_label) + synonym.word)
+                           Spacer(modifier = Modifier.height(4.dp))
+                           Text(text = stringResource(R.string.synonyms_jp_label) + synonym.japaneseMeaning)
+                       }
                    }
                    Spacer(modifier = Modifier.height(8.dp))
                    HorizontalDivider(thickness = 1.dp, color = Color.LightGray)

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/top/TopScreenViewModel.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/top/TopScreenViewModel.kt
@@ -46,7 +46,7 @@ class TopScreenViewModel : ViewModel() {
 
         /**該当する単語を抽出**/
         _filterData.value = if (normalizedWord.isBlank()) {
-           emptyList()
+            _csvData.value
         } else {
             _csvData.value.filter { value ->
                 value.englishMean.startsWith(normalizedWord)

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/top/TopScreenViewModel.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/top/TopScreenViewModel.kt
@@ -36,6 +36,7 @@ class TopScreenViewModel : ViewModel() {
                             }
                             emptyList()
                         }
+        initializeFilterList()
     }
 
     /**検索欄から文字を検索**/
@@ -51,6 +52,11 @@ class TopScreenViewModel : ViewModel() {
                 value.englishMean.startsWith(normalizedWord)
             }
         }
+    }
+
+    /**フィルターリストの初期化**/
+    fun initializeFilterList(){
+        _filterData.value = _csvData.value
     }
 
     /**特定の値を初期化**/

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/top/TopScreenViewModel.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/top/TopScreenViewModel.kt
@@ -19,6 +19,12 @@ class TopScreenViewModel : ViewModel() {
     private val _filterData = MutableStateFlow<List<Language>>(emptyList())
     val filterData: StateFlow<List<Language>> = _filterData.asStateFlow()
 
+    private val _searchWord = MutableStateFlow<String>("")
+    val searchWord: StateFlow<String> = _searchWord.asStateFlow()
+    fun setSearchWord(word: String){
+        _searchWord.value = word
+    }
+
     /**AssetからCSV読み込み csvDataで保持**/
     fun readCsvDataFromAsset(context : Context){
         _csvData.value = runCatching { readCsvDataFromAssets(context) }

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/SearchBar.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/SearchBar.kt
@@ -67,7 +67,7 @@ fun SearchBar(modifier: Modifier = Modifier,
                                 topScreenViewModel.apply {
                                     setSearchWord("")
                                     text = searchWord.value
-                                    initializeValues()
+                                    initializeFilterList()
                                 } },
                             indication = null, //indication = nullでリップル削除
                             interactionSource = remember { MutableInteractionSource() },),

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/SearchBar.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/SearchBar.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.KeyboardOptions
@@ -37,8 +36,7 @@ fun SearchBar(modifier: Modifier = Modifier,
     var text by remember { mutableStateOf("") }
 
     Row(modifier = Modifier
-        .padding(horizontal = 8.dp)
-        .fillMaxSize(),
+        .padding(horizontal = 8.dp),
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.Top){
         OutlinedTextField(

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/SearchBar.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/SearchBar.kt
@@ -1,20 +1,18 @@
 package biz.moapp.english_dictionary.ui.top.parts_compose
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.horizontalScroll
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Cancel
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -24,14 +22,10 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import biz.moapp.english_dictionary.R
 import biz.moapp.english_dictionary.ui.top.TopScreenViewModel
 
@@ -42,7 +36,9 @@ fun SearchBar(modifier: Modifier = Modifier,
 
     var text by remember { mutableStateOf("") }
 
-    Row(modifier = Modifier.padding(horizontal = 8.dp),
+    Row(modifier = Modifier
+        .padding(horizontal = 8.dp)
+        .fillMaxSize(),
         horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.Top){
         OutlinedTextField(
@@ -62,6 +58,15 @@ fun SearchBar(modifier: Modifier = Modifier,
                     Text(stringResource(R.string.search_bar_placeholders),)
                 }
             },
+            trailingIcon = {
+                if(text.isNotEmpty()){
+                    Icon(imageVector = Icons.Filled.Cancel,
+                        modifier = Modifier.clickable(onClick = {  },
+                            indication = null, //indication = nullでリップル削除
+                            interactionSource = remember { MutableInteractionSource() },),
+                        contentDescription = "")
+                }
+            }
         )
     }
 

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/SearchBar.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/SearchBar.kt
@@ -33,7 +33,7 @@ fun SearchBar(modifier: Modifier = Modifier,
               topScreenViewModel: TopScreenViewModel
 ){
 
-    var text by remember { mutableStateOf("") }
+    var text by remember { mutableStateOf(topScreenViewModel.searchWord.value) }
 
     Row(modifier = Modifier
         .padding(horizontal = 8.dp),
@@ -43,8 +43,11 @@ fun SearchBar(modifier: Modifier = Modifier,
             modifier = Modifier.fillMaxWidth(),
             value = text,
             onValueChange = { inputText ->
-                text = inputText
-                topScreenViewModel.searchLanguage(inputText)
+                topScreenViewModel.apply {
+                    setSearchWord(inputText)
+                    text = searchWord.value
+                    searchLanguage(inputText)
+                }
             },
             maxLines = 1,
             singleLine = true,

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/SearchBar.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/SearchBar.kt
@@ -62,7 +62,13 @@ fun SearchBar(modifier: Modifier = Modifier,
             trailingIcon = {
                 if(text.isNotEmpty()){
                     Icon(imageVector = Icons.Filled.Cancel,
-                        modifier = Modifier.clickable(onClick = { text = "" },
+                        modifier = Modifier
+                            .clickable(onClick = {
+                                topScreenViewModel.apply {
+                                    setSearchWord("")
+                                    text = searchWord.value
+                                    initializeValues()
+                                } },
                             indication = null, //indication = nullでリップル削除
                             interactionSource = remember { MutableInteractionSource() },),
                         contentDescription = "")

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/SearchBar.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/SearchBar.kt
@@ -61,7 +61,7 @@ fun SearchBar(modifier: Modifier = Modifier,
             trailingIcon = {
                 if(text.isNotEmpty()){
                     Icon(imageVector = Icons.Filled.Cancel,
-                        modifier = Modifier.clickable(onClick = {  },
+                        modifier = Modifier.clickable(onClick = { text = "" },
                             indication = null, //indication = nullでリップル削除
                             interactionSource = remember { MutableInteractionSource() },),
                         contentDescription = "")

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/SearchBar.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/SearchBar.kt
@@ -15,6 +15,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -41,42 +42,65 @@ fun SearchBar(modifier: Modifier = Modifier,
 
     var text by remember { mutableStateOf("") }
 
-    Row(modifier = Modifier.padding(horizontal = 8.dp)
-        .clip(RoundedCornerShape(8.dp))
-        .background(color = MaterialTheme.colorScheme.surfaceDim)
-        .border(1.dp,  MaterialTheme.colorScheme.outline, RoundedCornerShape(8.dp)),
+    Row(modifier = Modifier.padding(horizontal = 8.dp),
         horizontalArrangement = Arrangement.Center,
-        verticalAlignment = Alignment.Top) {
-        BasicTextField(
+        verticalAlignment = Alignment.Top){
+        OutlinedTextField(
+            modifier = Modifier.fillMaxWidth(),
             value = text,
             onValueChange = { inputText ->
                 text = inputText
                 topScreenViewModel.searchLanguage(inputText)
             },
             maxLines = 1,
+            singleLine = true,
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
             visualTransformation = VisualTransformation.None,
-            modifier = Modifier
-                .padding(6.dp)
-                .fillMaxWidth(),
-            decorationBox = { innerTextField ->
-                /**プレースホルダー**/
-                Row(
-                    Modifier
-                        .padding(8.dp)
-                        .horizontalScroll(rememberScrollState())) {
-                    if (text.isEmpty()) {
-                        Icon(imageVector = Icons.Filled.Search, contentDescription = "")
-                        Text(
-                            stringResource(R.string.search_bar_placeholders),
-                            color = Color.Gray,
-                            fontSize = 16.sp
-                        )
-                    }
-                    innerTextField()
+            placeholder = {
+                Row{
+                    Icon(imageVector = Icons.Filled.Search, contentDescription = "")
+                    Text(stringResource(R.string.search_bar_placeholders),)
                 }
             },
-            textStyle = TextStyle(fontSize = 18.sp),
         )
     }
+
+//    Row(modifier = Modifier.padding(horizontal = 8.dp)
+//        .clip(RoundedCornerShape(8.dp))
+//        .background(color = MaterialTheme.colorScheme.surfaceDim)
+//        .border(1.dp,  MaterialTheme.colorScheme.outline, RoundedCornerShape(8.dp)),
+//        horizontalArrangement = Arrangement.Center,
+//        verticalAlignment = Alignment.Top) {
+//        BasicTextField(
+//            value = text,
+//            onValueChange = { inputText ->
+//                text = inputText
+//                topScreenViewModel.searchLanguage(inputText)
+//            },
+//            maxLines = 1,
+//            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Text),
+//            visualTransformation = VisualTransformation.None,
+//            modifier = Modifier
+//                .padding(6.dp)
+//                .fillMaxWidth(),
+//            decorationBox = { innerTextField ->
+//                /**プレースホルダー**/
+//                Row(
+//                    Modifier
+//                        .padding(8.dp)
+//                        .horizontalScroll(rememberScrollState())) {
+//                    if (text.isEmpty()) {
+//                        Icon(imageVector = Icons.Filled.Search, contentDescription = "")
+//                        Text(
+//                            stringResource(R.string.search_bar_placeholders),
+//                            color = Color.Gray,
+//                            fontSize = 16.sp
+//                        )
+//                    }
+//                    innerTextField()
+//                }
+//            },
+//            textStyle = TextStyle(fontSize = 18.sp, color = Color.White),
+//        )
+//    }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,5 +14,9 @@
 
     <!--単語検索結果画面で表示-->
     <string name="search_result_error">単語の意味の取得に失敗しました。</string>
+
+    <!--類語タブで表示-->
+    <string name="synonyms_eng_label">英語：</string>
+    <string name="synonyms_jp_label">日本語：</string>
     
 </resources>


### PR DESCRIPTION
以下対応
- 初期表示画面で検索前から単語の一覧を並べる
→読み込んだCSVをそのまま表示するように修正

- ダークモード、検索ボックスの文字列が見えないので見えるように
→入力フィールド全体の見直し（OutlinedTextField利用）

- ✕ボタン配置して全部クリアできるように
→OutlinedTextFieldのtrailingIconに配置

- 検索一覧リストで下側にパーツ配置されてて一覧が隠れてる
→余計なフッダーの削除

- 類語の英単語をタップしても発音したい
→Synonymsタブに音声アイコン追加およびレイアウトの見直し

- Result画面から戻った際に入力していた値が表示されて、一覧も残ったままがいい
→戻った際に一覧初期化されるようにしてた処理を削除