### PR TITLE
軽微なUIの調整

### DIFF
--- a/app/src/main/java/biz/moapp/english_dictionary/MainActivity.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/MainActivity.kt
@@ -2,7 +2,6 @@ package biz.moapp.english_dictionary
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
-import androidx.activity.OnBackPressedCallback
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
@@ -21,9 +20,6 @@ class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        /**Homeの戻るの制御**/
-        onBackPressedDispatcher.addCallback(callback)
-
         /**AssetからCSV読み込み**/
         val topScreenViewModel: TopScreenViewModel by viewModels()
         topScreenViewModel.readCsvDataFromAsset(this)
@@ -40,13 +36,6 @@ class MainActivity : ComponentActivity() {
                     BaseScreen(topScreenViewModel, searchResultViewModel,)
                 }
             }
-        }
-    }
-    private val callback = object : OnBackPressedCallback(true) {
-        /**handleOnBackPressedを呼び出して、戻るキーを押したときの処理を記述**/
-        override fun handleOnBackPressed() {
-            /**ハードの戻るボタンでアプリ終了**/
-            return finish()
         }
     }
 }

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/base/BaseScreen.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/base/BaseScreen.kt
@@ -48,7 +48,8 @@ fun BaseScreen(topScreenViewModel: TopScreenViewModel, searchResultViewModel: Se
                 arguments = listOf(navArgument("keyWord") { type = NavType.StringType })
             ) {backStackEntry ->
                 val keyWord = backStackEntry.arguments?.getString("keyWord")
-                SearchResultScreen(Modifier.padding(innerPadding),keyWord, searchResultViewModel,)
+                SearchResultScreen(Modifier.padding(innerPadding), keyWord,
+                    searchResultViewModel, navController)
             }
         }
     }

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/SearchResultScreen.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/SearchResultScreen.kt
@@ -25,7 +25,10 @@ import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.currentBackStackEntryAsState
 import biz.moapp.english_dictionary.R
+import biz.moapp.english_dictionary.navigation.Nav
 import biz.moapp.english_dictionary.ui.search_result.parts_compose.tab_content.AntonymsTab
 import biz.moapp.english_dictionary.ui.search_result.parts_compose.tab_content.ExampleTab
 import biz.moapp.english_dictionary.ui.search_result.parts_compose.tab_content.MeanTab
@@ -35,7 +38,8 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun SearchResultScreen(modifier: Modifier = Modifier,keyWord :String? = "No KeyWord", searchResultViewModel: SearchResultViewModel,){
+fun SearchResultScreen(modifier: Modifier = Modifier,keyWord :String? = "No KeyWord",
+                       searchResultViewModel: SearchResultViewModel, navController:NavController){
     Column(modifier = modifier.fillMaxSize()) {
         /**タブ名前取得**/
         val tabLabels = stringArrayResource(R.array.tab_labels)
@@ -45,12 +49,17 @@ fun SearchResultScreen(modifier: Modifier = Modifier,keyWord :String? = "No KeyW
 
         var initialized by remember { mutableStateOf(false) }
         val tts = rememberTextToSpeech()
+        val backStackEntry by navController.currentBackStackEntryAsState()
 
         /**端末戻るボタンの制御**/
         BackHandler(
             enabled = true
         ) {
-            //ここに実行したい処理を記載(何もなけれ動作なしになる)
+            navController.navigate(Nav.TopScreen.name){
+                backStackEntry?.destination?.route?.let {
+                    popUpTo(it) { inclusive = true }
+                }
+            }
         }
 
         /**初期表示のための処理**/

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/SearchResultScreen.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/SearchResultScreen.kt
@@ -44,6 +44,7 @@ fun SearchResultScreen(modifier: Modifier = Modifier,keyWord :String? = "No KeyW
     Column(modifier = modifier.fillMaxSize()) {
         /**タブ名前取得**/
         val tabLabels = stringArrayResource(R.array.tab_labels)
+
         /**タブインデックスの保持**/
         val viewPagerState = rememberPagerState(pageCount = { 5 })
         val viewPagerScope = rememberCoroutineScope()
@@ -56,7 +57,7 @@ fun SearchResultScreen(modifier: Modifier = Modifier,keyWord :String? = "No KeyW
         BackHandler(
             enabled = true
         ) {
-            navController.navigate(Nav.TopScreen.name){
+            navController.navigate(Nav.TopScreen.name) {
                 backStackEntry?.destination?.route?.let {
                     popUpTo(it) { inclusive = true }
                 }
@@ -79,7 +80,7 @@ fun SearchResultScreen(modifier: Modifier = Modifier,keyWord :String? = "No KeyW
             selectedTabIndex = viewPagerState.currentPage,
             edgePadding = 0.dp
         ) {
-            tabLabels.forEachIndexed { index,value ->
+            tabLabels.forEachIndexed { index, value ->
 //                SideEffect {
 //                    Log.d("--TabRow", "index: ${index}")
 //                    Log.d("--TabRow", "value: ${value}")
@@ -100,62 +101,69 @@ fun SearchResultScreen(modifier: Modifier = Modifier,keyWord :String? = "No KeyW
                 )
             }
         }
+        HorizontalPager(state = viewPagerState) { pageNum ->
+                /**タブの内容**/
+                when (searchResultViewModel.resultUiState.sendResultState) {
+                    is ResultUiState.SendResultState.NotYet -> {}
+                    is ResultUiState.SendResultState.Loading -> {
+                        Column(
+                            modifier = modifier.fillMaxSize().padding(bottom = 120.dp),
+                            verticalArrangement = Arrangement.Center,
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            CircularProgressIndicator()
+                        }
+                    }
 
-        /**タブの内容**/
-        when(searchResultViewModel.resultUiState.sendResultState){
-            is ResultUiState.SendResultState.NotYet -> {}
-            is ResultUiState.SendResultState.Loading -> {
-                Column(modifier = modifier.fillMaxSize().padding(bottom = 120.dp),
-                    verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally) {
-                    CircularProgressIndicator()
-                }
-            }
-            is ResultUiState.SendResultState.Success -> {
-                (searchResultViewModel.resultUiState.sendResultState  as ResultUiState.SendResultState.Success).results?.let { data ->
-                    /**インデックスによってタブ内容が切り替わる**/
-                    HorizontalPager(state = viewPagerState) { pageNum->
-                        Column( modifier = Modifier.fillMaxSize(),
-                            verticalArrangement = Arrangement.Top,
-                            horizontalAlignment = Alignment.Start) {
-                            key(pageNum != viewPagerState.currentPage) {
-                                when (pageNum) {
-                                    0 -> {
-                                        MeanTab(
-                                            modifier,
-                                            keyWord ?: "No keyWord",
-                                            data.japaneseMeaning,tts.value
-                                        )
-                                    }
+                    is ResultUiState.SendResultState.Success -> {
+                        (searchResultViewModel.resultUiState.sendResultState as ResultUiState.SendResultState.Success).results?.let { data ->
+                            /**インデックスによってタブ内容が切り替わる**/
+                            Column(
+                                modifier = Modifier.fillMaxSize(),
+                                verticalArrangement = Arrangement.Top,
+                                horizontalAlignment = Alignment.Start
+                            ) {
+                                key(pageNum != viewPagerState.currentPage) {
+                                    when (pageNum) {
+                                        0 -> {
+                                            MeanTab(
+                                                modifier,
+                                                keyWord ?: "No keyWord",
+                                                data.japaneseMeaning, tts.value
+                                            )
+                                        }
 
-                                    1 -> {
-                                        SynonymsTab(modifier, data.synonyms, tts.value)
-                                    }
+                                        1 -> {
+                                            SynonymsTab(modifier, data.synonyms, tts.value)
+                                        }
 
-                                    2 -> {
-                                        AntonymsTab(modifier, data.antonyms, tts.value)
-                                    }
+                                        2 -> {
+                                            AntonymsTab(modifier, data.antonyms, tts.value)
+                                        }
 
-                                    3 -> {
-                                        ExampleTab(modifier, data.exampleSentences, tts.value)
-                                    }
+                                        3 -> {
+                                            ExampleTab(modifier, data.exampleSentences, tts.value)
+                                        }
 
-                                    4 -> {
-                                        WordRootsTab(data.wordRoots)
+                                        4 -> {
+                                            WordRootsTab(data.wordRoots)
+                                        }
                                     }
                                 }
+                            }
                         }
+                    }
+
+                    is ResultUiState.SendResultState.Error -> {
+                        Column(
+                            modifier = modifier.fillMaxSize(),
+                            verticalArrangement = Arrangement.Center,
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            Text(text = stringResource(R.string.search_result_error))
                         }
                     }
                 }
-            }
-            is ResultUiState.SendResultState.Error -> {
-                Column(modifier = modifier.fillMaxSize(),
-                    verticalArrangement = Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text(text = stringResource(R.string.search_result_error))
-                }
-            }
         }
     }
 }

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/SearchResultScreen.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/SearchResultScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.CircularProgressIndicator
@@ -104,7 +105,7 @@ fun SearchResultScreen(modifier: Modifier = Modifier,keyWord :String? = "No KeyW
         when(searchResultViewModel.resultUiState.sendResultState){
             is ResultUiState.SendResultState.NotYet -> {}
             is ResultUiState.SendResultState.Loading -> {
-                Column(modifier = modifier.fillMaxSize(),
+                Column(modifier = modifier.fillMaxSize().padding(bottom = 120.dp),
                     verticalArrangement = Arrangement.Center,
                     horizontalAlignment = Alignment.CenterHorizontally) {
                     CircularProgressIndicator()

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/SearchResultScreen.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/SearchResultScreen.kt
@@ -156,7 +156,7 @@ fun SearchResultScreen(modifier: Modifier = Modifier,keyWord :String? = "No KeyW
 
                     is ResultUiState.SendResultState.Error -> {
                         Column(
-                            modifier = modifier.fillMaxSize(),
+                            modifier = modifier.fillMaxSize().padding(bottom = 120.dp),
                             verticalArrangement = Arrangement.Center,
                             horizontalAlignment = Alignment.CenterHorizontally
                         ) {

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/SearchResultViewModel.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/SearchResultViewModel.kt
@@ -72,24 +72,39 @@ class SearchResultViewModel
                                 Log.d("--wordInfo Json", "${result.choices[0].message?.content}")
 
                                 /**受け取ったレスポンスをJsonに整形してWordInfoに変換**/
-                                val wordInfo =
+                                val convertJsonResult =
                                     convertJsonToWordInfo(result.choices[0].message?.content ?: "")
-                                /**一度検索したものは履歴として残す**/
-                                wordInfo?.let {
-                                    _searchHistory.value = mutableMapOf(word to it)
-                                }
-                                Log.d("--wordInfo japaneseMeaning", "${wordInfo?.japaneseMeaning}")
-                                Log.d("--wordInfo exampleSentences", "${wordInfo?.exampleSentences}")
-                                Log.d("--wordInfo synonyms", "${wordInfo?.synonyms}")
-                                Log.d("--wordInfo antonyms", "${wordInfo?.antonyms}")
-                                Log.d("--wordInfo wordRoots", "${wordInfo?.wordRoots}")
 
-                                resultUiState.copy(
-                                    result = wordInfo,
-                                    sendResultState = ResultUiState.SendResultState.Success(
-                                        wordInfo
-                                    )
-                                )
+                                /**変換失敗したか判定**/
+                               if(convertJsonResult.isSuccess){
+                                   convertJsonResult.getOrNull().let { wordInfo ->
+                                       /**一度検索したものは履歴として残す**/
+                                       wordInfo?.let {
+                                           _searchHistory.value = mutableMapOf(word to it)
+                                       }
+
+                                       Log.d("--wordInfo japaneseMeaning", "${wordInfo?.japaneseMeaning}")
+                                       Log.d("--wordInfo exampleSentences", "${wordInfo?.exampleSentences}")
+                                       Log.d("--wordInfo synonyms", "${wordInfo?.synonyms}")
+                                       Log.d("--wordInfo antonyms", "${wordInfo?.antonyms}")
+                                       Log.d("--wordInfo wordRoots", "${wordInfo?.wordRoots}")
+
+                                       /**ステータス更新（成功）**/
+                                       resultUiState.copy(
+                                           result = wordInfo,
+                                           sendResultState = ResultUiState.SendResultState.Success(
+                                               wordInfo
+                                           )
+                                       )
+                                   }
+                               }else{
+                                   /**ステータス更新（失敗）**/
+                                   resultUiState.copy(
+                                       sendResultState = ResultUiState.SendResultState.Error(
+                                           "JSON Error"
+                                       )
+                                   )
+                               }
                             }
 
                             is ChatCompletions.Response.Failure -> {
@@ -101,7 +116,7 @@ class SearchResultViewModel
                             }
                         }
                     }.onFailure { e ->
-                        Log.e("--getEnglishMean Error", "Message:${e.message}", e)
+                        Log.e("--Error", "getEnglishMean  Message:${e.message}", e)
                     }
             }
         }

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/top/TopScreen.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/top/TopScreen.kt
@@ -34,7 +34,7 @@ fun TopScreen(modifier: Modifier = Modifier,
 
     /**端末戻るボタンの制御**/
     BackHandler(
-        enabled = true
+        enabled = false
     ) {
         //ここに実行したい処理を記載(何もなけれ動作なしになる)
     }

--- a/app/src/main/java/biz/moapp/english_dictionary/utill/JsonUtil.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/utill/JsonUtil.kt
@@ -6,8 +6,8 @@ import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 
 object JsonUtil {
-    fun convertJsonToWordInfo(rowJson:String) :WordInfo?{
-        try {
+    fun convertJsonToWordInfo(rowJson:String) :Result<WordInfo>{
+        return runCatching {
             val json = rowJson
                 .replace("\n", "")
                 .replace("  ", "")
@@ -23,11 +23,10 @@ object JsonUtil {
 
             val adapter = moshi.adapter(WordInfo::class.java)
 
-            return adapter.fromJson(json)
-        }catch (e:Exception){
-            Log.e("--Error convertJsonToWordInfo","Message: ${e.message}",e)
+            adapter.fromJson(json)!!
+        }.onFailure { e ->
+            Log.e("--Error", "convertJsonToWordInfo  Message:${e.message}", e)
         }
-       return null
     }
 
     fun convertStringToList(japaneseMeaning :String) :List<String>{


### PR DESCRIPTION
以下指摘内容対応

- 任意の単語タップ後にタブが出てるけど、ぐるぐるの間にタブを切り替えたい
（タブは表示したままで、ローディングが表示されている最中にタブを切り替えられないからそれの有効化）
- 詳細画面でハードボタンの戻るを効かせる　
- ローディングアニメーションが中央揃えにする
- 初期画面もハードキーの戻るでアプリ終了
- 詳細画面でローディング後何も表示されないケースがあるので、表示されない場合、エラーを表示
→JSON変換時の処理のメソッドのエラーハンドリングに引っかかった際にUIのステータスが更新されない様になってしまったため更新されるように調整