### PR TITLE
タイトル（詳細画面の「英単語辞典」）をタップしたアイテムに変更

### DIFF
--- a/app/src/main/java/biz/moapp/english_dictionary/ui/base/BaseScreen.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/base/BaseScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -13,7 +14,6 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import biz.moapp.english_dictionary.navigation.Nav
-import biz.moapp.english_dictionary.ui.common.BottomBar
 import biz.moapp.english_dictionary.ui.common.TopBar
 import biz.moapp.english_dictionary.ui.search_result.SearchResultScreen
 import biz.moapp.english_dictionary.ui.search_result.SearchResultViewModel
@@ -23,7 +23,8 @@ import biz.moapp.english_dictionary.ui.top.TopScreenViewModel
 @Composable
 fun BaseScreen(topScreenViewModel: TopScreenViewModel, searchResultViewModel: SearchResultViewModel,) {
     val navController = rememberNavController()
-    Scaffold(modifier = Modifier.fillMaxSize(), topBar = { TopBar(navController) }, /*bottomBar = { BottomBar()}*/){  innerPadding ->
+    val searchWord = searchResultViewModel.searchKeyWord.collectAsState()
+    Scaffold(modifier = Modifier.fillMaxSize(), topBar = { TopBar(navController, searchWord.value) }, /*bottomBar = { BottomBar()}*/){  innerPadding ->
         NavHost(
             navController = navController, startDestination = Nav.TopScreen.name,
             enterTransition = {

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/common/TopBar.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/common/TopBar.kt
@@ -19,13 +19,16 @@ import biz.moapp.english_dictionary.navigation.Nav
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TopBar(navController :NavController){
+fun TopBar(navController :NavController, searchWord :String){
     val backStackEntry by navController.currentBackStackEntryAsState()
     val selectedRoute = backStackEntry?.destination?.route
+    /**検索結果画面のタイトルに表示、初期画面の場合はアプリタイトル**/
+    val title = if(selectedRoute != Nav.TopScreen.name) searchWord else stringResource(R.string.app_name)
+
     CenterAlignedTopAppBar(
         title = {
             Text(
-                text = stringResource(R.string.app_name),
+                text = title,
                 fontWeight = FontWeight.Bold
             )
         },

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/SearchResultViewModel.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/SearchResultViewModel.kt
@@ -32,10 +32,16 @@ class SearchResultViewModel
     private val _searchHistory = MutableStateFlow<Map<String, WordInfo>>(emptyMap())
     val searchHistory: StateFlow<Map<String, WordInfo>> = _searchHistory.asStateFlow()
 
+    private val _searchKeyWord = MutableStateFlow<String>("")
+    val searchKeyWord: StateFlow<String> = _searchKeyWord.asStateFlow()
+
     var resultUiState by mutableStateOf(ResultUiState())
         private set
 
     fun getEnglishMean(word :String){
+        /**選択した単語を保持、検索結果画面のタイトルに表示**/
+        _searchKeyWord.value = word
+
         viewModelScope.launch {
             /**ローディング**/
             resultUiState = resultUiState.copy(sendResultState = ResultUiState.SendResultState.Loading)


### PR DESCRIPTION
- 詳細画面ではTOP画面でタップしたリスト要素の英単語をTOPバーのタイトルに表示
- TOP画面では「英単語辞典」とタイトルを表示