### PR TITLE
AdMob広告の追加

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -100,4 +100,7 @@ dependencies {
 
     /**マテリアルデザインのアイコン追加パッケージ**/
     implementation (libs.androidx.material.icons.extended)
+
+    /**Ad_Mob**/
+    implementation(libs.admob)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -51,6 +51,7 @@ android {
     }
     buildFeatures {
         compose = true
+        dataBinding=true
     }
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.1"
@@ -72,6 +73,8 @@ dependencies {
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
+    /**constraintlayout**/
+    implementation(libs.androidx.constraintlayout)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,9 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-5071120464333172~5372936201"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/biz/moapp/english_dictionary/MainActivity.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/MainActivity.kt
@@ -1,8 +1,6 @@
 package biz.moapp.english_dictionary
 
 import android.os.Bundle
-import android.util.DisplayMetrics
-import android.util.Log
 import android.widget.ImageView
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -12,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
 import androidx.databinding.DataBindingUtil
 import biz.moapp.english_dictionary.databinding.NativeAdLayoutBinding
 import biz.moapp.english_dictionary.ui.base.BaseScreen

--- a/app/src/main/java/biz/moapp/english_dictionary/MainActivity.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/MainActivity.kt
@@ -2,6 +2,8 @@ package biz.moapp.english_dictionary
 
 import android.os.Bundle
 import android.util.DisplayMetrics
+import android.util.Log
+import android.widget.ImageView
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -11,18 +13,25 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.databinding.DataBindingUtil
+import biz.moapp.english_dictionary.databinding.NativeAdLayoutBinding
 import biz.moapp.english_dictionary.ui.base.BaseScreen
 import biz.moapp.english_dictionary.ui.search_result.SearchResultViewModel
 import biz.moapp.english_dictionary.ui.theme.English_dictionaryTheme
 import biz.moapp.english_dictionary.ui.top.TopScreenViewModel
+import com.google.android.gms.ads.AdLoader
 import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.AdSize
 import com.google.android.gms.ads.AdView
 import com.google.android.gms.ads.MobileAds
+import com.google.android.gms.ads.nativead.NativeAdView
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    private var nativeAdLayoutBinding: NativeAdLayoutBinding? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -34,6 +43,9 @@ class MainActivity : ComponentActivity() {
         banner.setAdSize(AdSize.BANNER)
         banner.adUnitId = getString(R.string.banner_ad_id_test)
         banner.loadAd(AdRequest.Builder().build())
+
+        /**ネイティブ広告の初期化**/
+        initNativeAd()
 
         /**AssetからCSV読み込み**/
         val topScreenViewModel: TopScreenViewModel by viewModels()
@@ -48,9 +60,40 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    BaseScreen(topScreenViewModel, searchResultViewModel, banner)
+                    BaseScreen(topScreenViewModel, searchResultViewModel, banner,
+                        nativeAdView = nativeAdLayoutBinding!!.root as NativeAdView)
                 }
             }
         }
+    }
+    override fun onDestroy() {
+        super.onDestroy()
+        /**広告の解放**/
+        (nativeAdLayoutBinding?.root as? NativeAdView)?.destroy()
+    }
+
+    /**ネイティブ広告の初期化**/
+    private fun initNativeAd() {
+        nativeAdLayoutBinding = DataBindingUtil.inflate(
+            layoutInflater,
+            R.layout.native_ad_layout,
+            null,
+            false
+        )
+        AdLoader.Builder(this, getString(R.string.admob_native_unit_id_test))
+            .forNativeAd { ad ->
+                val nativeAdView = nativeAdLayoutBinding!!.root as NativeAdView
+
+                nativeAdView.mediaView = nativeAdLayoutBinding!!.adMedia
+                nativeAdLayoutBinding!!.adMedia.setImageScaleType(ImageView.ScaleType.FIT_CENTER)
+                nativeAdView.headlineView = nativeAdLayoutBinding!!.adHeadline
+                nativeAdLayoutBinding!!.adHeadline.text = ad.headline
+                nativeAdView.bodyView = nativeAdLayoutBinding!!.adBody
+                nativeAdLayoutBinding!!.adBody.text = ad.body
+                nativeAdView.adChoicesView = nativeAdLayoutBinding!!.adChoices
+                nativeAdView.advertiserView = nativeAdLayoutBinding!!.adAdvertiser
+                nativeAdLayoutBinding!!.adAdvertiser.text = ad.advertiser
+                nativeAdView.setNativeAd(ad)
+            }.build().loadAd(AdRequest.Builder().build())
     }
 }

--- a/app/src/main/java/biz/moapp/english_dictionary/MainActivity.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/MainActivity.kt
@@ -1,6 +1,7 @@
 package biz.moapp.english_dictionary
 
 import android.os.Bundle
+import android.util.DisplayMetrics
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -9,16 +10,30 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import biz.moapp.english_dictionary.ui.base.BaseScreen
 import biz.moapp.english_dictionary.ui.search_result.SearchResultViewModel
 import biz.moapp.english_dictionary.ui.theme.English_dictionaryTheme
 import biz.moapp.english_dictionary.ui.top.TopScreenViewModel
+import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.AdSize
+import com.google.android.gms.ads.AdView
+import com.google.android.gms.ads.MobileAds
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        /**AdMob初期化**/
+        MobileAds.initialize(this)
+
+        /**AdMob　バナー広告**/
+        val banner = AdView(this)
+        banner.setAdSize(AdSize.BANNER)
+        banner.adUnitId = getString(R.string.banner_ad_id_test)
+        banner.loadAd(AdRequest.Builder().build())
 
         /**AssetからCSV読み込み**/
         val topScreenViewModel: TopScreenViewModel by viewModels()
@@ -33,7 +48,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    BaseScreen(topScreenViewModel, searchResultViewModel,)
+                    BaseScreen(topScreenViewModel, searchResultViewModel, banner)
                 }
             }
         }

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/base/BaseScreen.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/base/BaseScreen.kt
@@ -19,9 +19,10 @@ import biz.moapp.english_dictionary.ui.search_result.SearchResultScreen
 import biz.moapp.english_dictionary.ui.search_result.SearchResultViewModel
 import biz.moapp.english_dictionary.ui.top.TopScreen
 import biz.moapp.english_dictionary.ui.top.TopScreenViewModel
+import com.google.android.gms.ads.AdView
 
 @Composable
-fun BaseScreen(topScreenViewModel: TopScreenViewModel, searchResultViewModel: SearchResultViewModel,) {
+fun BaseScreen(topScreenViewModel: TopScreenViewModel, searchResultViewModel: SearchResultViewModel, banner: AdView) {
     val navController = rememberNavController()
     val searchWord = searchResultViewModel.searchKeyWord.collectAsState()
     Scaffold(modifier = Modifier.fillMaxSize(), topBar = { TopBar(navController, searchWord.value) }, /*bottomBar = { BottomBar()}*/){  innerPadding ->
@@ -43,7 +44,7 @@ fun BaseScreen(topScreenViewModel: TopScreenViewModel, searchResultViewModel: Se
             composable(route = Nav.TopScreen.name,) {
                 TopScreen(Modifier.padding(innerPadding),
                     topScreenViewModel,
-                    navController)
+                    navController, banner)
             }
             composable(route = "${Nav.SearchResultScreen.name}/{keyWord}",
                 arguments = listOf(navArgument("keyWord") { type = NavType.StringType })

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/base/BaseScreen.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/base/BaseScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -20,11 +21,14 @@ import biz.moapp.english_dictionary.ui.search_result.SearchResultViewModel
 import biz.moapp.english_dictionary.ui.top.TopScreen
 import biz.moapp.english_dictionary.ui.top.TopScreenViewModel
 import com.google.android.gms.ads.AdView
+import com.google.android.gms.ads.nativead.NativeAdView
 
 @Composable
-fun BaseScreen(topScreenViewModel: TopScreenViewModel, searchResultViewModel: SearchResultViewModel, banner: AdView) {
+fun BaseScreen(topScreenViewModel: TopScreenViewModel, searchResultViewModel: SearchResultViewModel,
+               banner: AdView, nativeAdView: NativeAdView,) {
     val navController = rememberNavController()
     val searchWord = searchResultViewModel.searchKeyWord.collectAsState()
+    val nativeAd = remember { nativeAdView }
     Scaffold(modifier = Modifier.fillMaxSize(), topBar = { TopBar(navController, searchWord.value) }, /*bottomBar = { BottomBar()}*/){  innerPadding ->
         NavHost(
             navController = navController, startDestination = Nav.TopScreen.name,
@@ -51,7 +55,7 @@ fun BaseScreen(topScreenViewModel: TopScreenViewModel, searchResultViewModel: Se
             ) {backStackEntry ->
                 val keyWord = backStackEntry.arguments?.getString("keyWord")
                 SearchResultScreen(Modifier.padding(innerPadding), keyWord,
-                    searchResultViewModel, navController)
+                    searchResultViewModel, navController, nativeAd)
             }
         }
     }

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/SearchResultScreen.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/SearchResultScreen.kt
@@ -1,5 +1,6 @@
 package biz.moapp.english_dictionary.ui.search_result
 
+import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
@@ -35,12 +36,15 @@ import biz.moapp.english_dictionary.ui.search_result.parts_compose.tab_content.E
 import biz.moapp.english_dictionary.ui.search_result.parts_compose.tab_content.MeanTab
 import biz.moapp.english_dictionary.ui.search_result.parts_compose.tab_content.SynonymsTab
 import biz.moapp.english_dictionary.ui.search_result.parts_compose.tab_content.WordRootsTab
+import com.google.android.gms.ads.nativead.NativeAdView
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun SearchResultScreen(modifier: Modifier = Modifier,keyWord :String? = "No KeyWord",
-                       searchResultViewModel: SearchResultViewModel, navController:NavController){
+fun SearchResultScreen(modifier: Modifier = Modifier, keyWord :String? = "No KeyWord",
+                       searchResultViewModel: SearchResultViewModel, navController:NavController,
+                       nativeAdView: NativeAdView,){
+    Log.d("--nativeAdView2", "SearchResultScreen:${nativeAdView.parent}")
     Column(modifier = modifier.fillMaxSize()) {
         /**タブ名前取得**/
         val tabLabels = stringArrayResource(R.array.tab_labels)
@@ -129,7 +133,8 @@ fun SearchResultScreen(modifier: Modifier = Modifier,keyWord :String? = "No KeyW
                                             MeanTab(
                                                 modifier,
                                                 keyWord ?: "No keyWord",
-                                                data.japaneseMeaning, tts.value
+                                                data.japaneseMeaning, tts.value,
+                                                nativeAdView
                                             )
                                         }
 

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/parts_compose/NativeAds.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/parts_compose/NativeAds.kt
@@ -1,0 +1,25 @@
+package biz.moapp.english_dictionary.ui.search_result.parts_compose
+
+import android.widget.FrameLayout
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import biz.moapp.english_dictionary.R
+import com.google.android.gms.ads.nativead.NativeAdView
+
+@Composable
+fun NativeAds(nativeAdView: NativeAdView){
+    AndroidView(modifier = Modifier.fillMaxWidth(),
+        factory = { context ->
+
+            if(nativeAdView.parent != null){
+                (nativeAdView.parent as FrameLayout).removeAllViews()
+            }
+
+            FrameLayout(context).apply {
+                minimumHeight = context.resources.getDimensionPixelSize(R.dimen.native_ad_height)
+                addView(nativeAdView)
+            }
+        })
+}

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/parts_compose/tab_content/MeanTab.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/parts_compose/tab_content/MeanTab.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -17,10 +17,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import biz.moapp.english_dictionary.ui.search_result.parts_compose.NativeAds
 import biz.moapp.english_dictionary.ui.search_result.parts_compose.SoundIcon
+import com.google.android.gms.ads.nativead.NativeAdView
 
 @Composable
-fun MeanTab(modifier: Modifier = Modifier, keyWord: String, data: List<String>, tts: TextToSpeech?,){
+fun MeanTab(modifier: Modifier = Modifier, keyWord: String, data: List<String>, tts: TextToSpeech?,
+            nativeAdView: NativeAdView,){
     val onClick = remember(tts, keyWord) {
         { tts?.speak(keyWord, TextToSpeech.QUEUE_ADD, null, null) }
     }
@@ -43,7 +46,7 @@ fun MeanTab(modifier: Modifier = Modifier, keyWord: String, data: List<String>, 
 
     /**日本語意味のリスト**/
     LazyColumn(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier.fillMaxHeight(0.4f),
         contentPadding = PaddingValues(4.dp),
         horizontalAlignment = Alignment.Start
     ) {
@@ -51,4 +54,6 @@ fun MeanTab(modifier: Modifier = Modifier, keyWord: String, data: List<String>, 
             Text(text = "・${value}")
         }
     }
+    /**ネイティブ広告表示**/
+    NativeAds(nativeAdView)
 }

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/top/TopScreen.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/top/TopScreen.kt
@@ -1,25 +1,35 @@
 package biz.moapp.english_dictionary.ui.top
 
+import android.widget.FrameLayout
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.navigation.NavController
 import biz.moapp.english_dictionary.R
+import biz.moapp.english_dictionary.ui.top.parts_compose.BannerAds
 import biz.moapp.english_dictionary.ui.top.parts_compose.ScrollBarList
 import biz.moapp.english_dictionary.ui.top.parts_compose.SearchBar
+import com.google.android.gms.ads.AdSize
+import com.google.android.gms.ads.AdView
 
 @Composable
 fun TopScreen(modifier: Modifier = Modifier,
               topScreenViewModel: TopScreenViewModel,
-              navController: NavController) {
+              navController: NavController,
+              banner: AdView) {
 
     val filterData = topScreenViewModel.filterData.collectAsState()
 
@@ -36,6 +46,10 @@ fun TopScreen(modifier: Modifier = Modifier,
         verticalArrangement = Arrangement.Top,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
+        /**バナー広告**/
+        BannerAds(banner)
+        Spacer(modifier = Modifier.height(8.dp))
+
         /**検索バー**/
         SearchBar(modifier, topScreenViewModel)
 

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/top/TopScreen.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/top/TopScreen.kt
@@ -50,6 +50,7 @@ fun TopScreen(modifier: Modifier = Modifier,
         SearchBar(modifier, topScreenViewModel)
 
         if(filterData.value.isEmpty()){
+            Spacer(modifier = Modifier.height(4.dp))
             Box(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/top/TopScreen.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/top/TopScreen.kt
@@ -1,13 +1,11 @@
 package biz.moapp.english_dictionary.ui.top
 
-import android.widget.FrameLayout
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -16,13 +14,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.viewinterop.AndroidView
 import androidx.navigation.NavController
 import biz.moapp.english_dictionary.R
 import biz.moapp.english_dictionary.ui.top.parts_compose.BannerAds
 import biz.moapp.english_dictionary.ui.top.parts_compose.ScrollBarList
 import biz.moapp.english_dictionary.ui.top.parts_compose.SearchBar
-import com.google.android.gms.ads.AdSize
 import com.google.android.gms.ads.AdView
 
 @Composable

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/BannerAds.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/BannerAds.kt
@@ -1,0 +1,26 @@
+package biz.moapp.english_dictionary.ui.top.parts_compose
+
+import android.widget.FrameLayout
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+import com.google.android.gms.ads.AdSize
+import com.google.android.gms.ads.AdView
+
+@Composable
+fun BannerAds(banner: AdView){
+    AndroidView(
+        modifier = Modifier.fillMaxWidth(),
+        factory = { context ->
+            if(banner.parent != null){
+                (banner.parent as FrameLayout).removeAllViews()
+            }
+            FrameLayout(context).apply {
+                minimumHeight = AdSize.BANNER.getHeightInPixels(context)
+                minimumWidth = AdSize.FULL_WIDTH
+                addView(banner)
+            }
+        }
+    )
+}

--- a/app/src/main/java/biz/moapp/english_dictionary/utill/AdMobUtil.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/utill/AdMobUtil.kt
@@ -1,0 +1,25 @@
+package biz.moapp.english_dictionary.utill
+
+import biz.moapp.english_dictionary.BuildConfig
+
+/**デバッグの場合はテスト用、本番では本番用IDを利用する様にする**/
+object AdMobUtil {
+
+    /**バナー広告IDの取得**/
+    fun getBannerAdUnitId(): String {
+        return if (BuildConfig.DEBUG) {
+            "ca-app-pub-3940256099942544/6300978111"
+        } else {
+            "ca-app-pub-5071120464333172/7299465232"
+        }
+    }
+
+    /**ネイティブ広告IDの取得**/
+    fun getNativeAdUnitId(): String {
+        return if (BuildConfig.DEBUG) {
+            "ca-app-pub-3940256099942544/2247696110"
+        } else {
+            "ca-app-pub-5071120464333172/6206709563"
+        }
+    }
+}

--- a/app/src/main/res/layout/native_ad_layout.xml
+++ b/app/src/main/res/layout/native_ad_layout.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <com.google.android.gms.ads.nativead.NativeAdView
+        android:layout_width="match_parent"
+        android:padding="8dp"
+        android:layout_height="@dimen/native_ad_height">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <!--メディア-->
+            <com.google.android.gms.ads.nativead.MediaView
+                android:id="@+id/ad_media"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <!--iマーク-->
+            <com.google.android.gms.ads.nativead.AdChoicesView
+                android:id="@+id/ad_choices"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <!--ヘッドライン-->
+            <TextView
+                android:id="@+id/ad_headline"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="8dp"
+                android:textColor="@android:color/black"
+                android:textSize="16sp"
+                android:textStyle="bold"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/ad_media" />
+
+            <!--本文-->
+            <TextView
+                android:id="@+id/ad_body"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="8dp"
+                android:textColor="@android:color/black"
+                android:textSize="12sp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/ad_headline" />
+
+            <!--広告主-->
+            <TextView
+                android:id="@+id/ad_advertiser"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:textColor="@android:color/black"
+                android:textSize="12sp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/ad_body" />
+
+            <TextView
+                android:id="@+id/ad_sample"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="8dp"
+                android:textColor="@android:color/black"
+                android:value="試し"
+                android:textSize="12sp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/ad_advertiser" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.gms.ads.nativead.NativeAdView>
+</layout>

--- a/app/src/main/res/values/dimen.xml
+++ b/app/src/main/res/values/dimen.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <dimen name="native_ad_height">350dp</dimen>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,12 +9,10 @@
         <item>語源</item>
     </array>
 
-    <!--Banner広告のID-->
-    <string name="banner_ad_id">ca-app-pub-5071120464333172/7299465232</string>
+    <!--Banner広告のID（テスト用）-->
     <string name="banner_ad_id_test">ca-app-pub-3940256099942544/6300978111</string>
-    <string name="admob_native_unit_id">ca-app-pub-5071120464333172/6206709563</string>
     <string name="admob_native_unit_id_test">ca-app-pub-3940256099942544/2247696110</string>
-    
+
     <!--Top画面で表示-->
     <string name="search_bar_placeholders">検索したい単語を英字入力</string>
     <string name="search_result_nothing">該当する単語がありません</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,8 @@
     <!--Banner広告のID-->
     <string name="banner_ad_id">ca-app-pub-5071120464333172/7299465232</string>
     <string name="banner_ad_id_test">ca-app-pub-3940256099942544/6300978111</string>
+    <string name="admob_native_unit_id">ca-app-pub-5071120464333172/6206709563</string>
+    <string name="admob_native_unit_id_test">ca-app-pub-3940256099942544/2247696110</string>
     
     <!--Top画面で表示-->
     <string name="search_bar_placeholders">検索したい単語を英字入力</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,6 +8,10 @@
         <item>例文</item>
         <item>語源</item>
     </array>
+
+    <!--Banner広告のID-->
+    <string name="banner_ad_id">ca-app-pub-5071120464333172/7299465232</string>
+    <string name="banner_ad_id_test">ca-app-pub-3940256099942544/6300978111</string>
     
     <!--Top画面で表示-->
     <string name="search_bar_placeholders">検索したい単語を英字入力</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,6 +30,8 @@ firebaseBom = "33.1.2"
 materialIconsExtended = "1.7.0-beta05"
 #AdMob
 ads = "23.3.0"
+#constraintlayout
+constraintlayout = "2.1.4"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -68,6 +70,8 @@ firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "materialIconsExtended" }
 #AdMob
 admob = { group = "com.google.android.gms", name = "play-services-ads", version.ref = "ads"}
+#constraintlayout
+androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,8 @@ firebaseFirestoreKtx = "25.0.0"
 firebaseBom = "33.1.2"
 #Material-icons-extended
 materialIconsExtended = "1.7.0-beta05"
+#AdMob
+ads = "23.3.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -64,6 +66,8 @@ firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "fir
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 #Material-icons-extended
 androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "materialIconsExtended" }
+#AdMob
+admob = { group = "com.google.android.gms", name = "play-services-ads", version.ref = "ads"}
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
以下実装
- 初期画面（TopScreen)の一番上にバナー広告配置
- 検索結果表示画面(SearchResult Screen)の意味のタブの一番したにネイティブ広告追加
- 一旦レビューのためテスト用の広告IDを利用して表示

参考文献
[JetPackComposeでAdMob実装](https://speakerdeck.com/kkkkan/jetpack-compose-x-admob)