### PR TITLE
20240924の指摘取り込み

### DIFF
--- a/app/src/main/java/biz/moapp/english_dictionary/ui/base/BaseScreen.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/base/BaseScreen.kt
@@ -46,6 +46,9 @@ fun BaseScreen(topScreenViewModel: TopScreenViewModel, searchResultViewModel: Se
             },
         ) {
             composable(route = Nav.TopScreen.name,) {
+                /**初期画面のためSearchResultView画面初期化**/
+                searchResultViewModel.clearSearchResultView()
+
                 TopScreen(Modifier.padding(innerPadding),
                     topScreenViewModel,
                     navController, banner)

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/SearchResultScreen.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/SearchResultScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import biz.moapp.english_dictionary.R
@@ -101,6 +102,7 @@ fun SearchResultScreen(modifier: Modifier = Modifier, keyWord :String? = "No Key
                         Text(
                             text = value,
                             fontWeight = FontWeight.Bold,
+                            fontSize = 12.sp
                         )
                     }
                 )

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/SearchResultScreen.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/SearchResultScreen.kt
@@ -6,12 +6,13 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.ScrollableTabRow
 import androidx.compose.material3.Tab
+import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -80,9 +81,9 @@ fun SearchResultScreen(modifier: Modifier = Modifier, keyWord :String? = "No Key
 //        SideEffect {
 //            Log.d("--TabRow", "currentPage1: ${viewPagerState.currentPage}")
 //        }
-        ScrollableTabRow(
+       TabRow(
+            modifier = Modifier.fillMaxWidth(),
             selectedTabIndex = viewPagerState.currentPage,
-            edgePadding = 0.dp
         ) {
             tabLabels.forEachIndexed { index, value ->
 //                SideEffect {

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/SearchResultViewModel.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/SearchResultViewModel.kt
@@ -124,7 +124,13 @@ class SearchResultViewModel
                     }.onFailure { e ->
                         Log.e("--Error", "getEnglishMean  Message:${e.message}", e)
                     }
-            }
+                }
         }
     }
+
+    /**遷移時の画面初期化**/
+    fun clearSearchResultView(){
+        resultUiState = resultUiState.copy(sendResultState = ResultUiState.SendResultState.NotYet)
+    }
+
  }

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/top/TopScreen.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/top/TopScreen.kt
@@ -42,9 +42,6 @@ fun TopScreen(modifier: Modifier = Modifier,
         verticalArrangement = Arrangement.Top,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        /**バナー広告**/
-        BannerAds(banner)
-        Spacer(modifier = Modifier.height(8.dp))
 
         /**検索バー**/
         SearchBar(modifier, topScreenViewModel)
@@ -60,6 +57,8 @@ fun TopScreen(modifier: Modifier = Modifier,
         }else {
             /**単語表示**/
             ScrollBarList(filterData.value, navController)
+            /**バナー広告**/
+            BannerAds(banner)
         }
     }
 }

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/top/TopScreen.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/top/TopScreen.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import biz.moapp.english_dictionary.R
-import biz.moapp.english_dictionary.ui.top.parts_compose.BannerAds
 import biz.moapp.english_dictionary.ui.top.parts_compose.ScrollBarList
 import biz.moapp.english_dictionary.ui.top.parts_compose.SearchBar
 import com.google.android.gms.ads.AdView
@@ -56,9 +55,7 @@ fun TopScreen(modifier: Modifier = Modifier,
             }
         }else {
             /**単語表示**/
-            ScrollBarList(filterData.value, navController)
-            /**バナー広告**/
-            BannerAds(banner)
+            ScrollBarList(filterData.value, navController, banner)
         }
     }
 }

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/BannerAds.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/BannerAds.kt
@@ -5,17 +5,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.google.android.gms.ads.AdSize
 import com.google.android.gms.ads.AdView
 
 @Composable
-fun BannerAds(banner: AdView){
+fun BannerAds(banner: AdView, maxHeight: Dp){
     /**画面全体を取得　全体の８割の高さのパディング入れる様にする**/
-    val configuration = LocalConfiguration.current
-    val screenHeight = (configuration.screenHeightDp  * 0.78f).dp
+    val screenHeight = (maxHeight  * 0.85f)
 
     AndroidView(
         modifier = Modifier.fillMaxWidth().padding(top = screenHeight),

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/BannerAds.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/BannerAds.kt
@@ -2,16 +2,23 @@ package biz.moapp.english_dictionary.ui.top.parts_compose
 
 import android.widget.FrameLayout
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import com.google.android.gms.ads.AdSize
 import com.google.android.gms.ads.AdView
 
 @Composable
 fun BannerAds(banner: AdView){
+    /**画面全体を取得　全体の８割の高さのパディング入れる様にする**/
+    val configuration = LocalConfiguration.current
+    val screenHeight = (configuration.screenHeightDp  * 0.78f).dp
+
     AndroidView(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier.fillMaxWidth().padding(top = screenHeight),
         factory = { context ->
             if(banner.parent != null){
                 (banner.parent as FrameLayout).removeAllViews()

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/BannerAds.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/BannerAds.kt
@@ -13,7 +13,7 @@ import com.google.android.gms.ads.AdView
 @Composable
 fun BannerAds(banner: AdView, maxHeight: Dp){
     /**画面全体を取得　全体の８割の高さのパディング入れる様にする**/
-    val screenHeight = (maxHeight  * 0.85f)
+    val screenHeight = (maxHeight  * 0.9f)
 
     AndroidView(
         modifier = Modifier.fillMaxWidth().padding(top = screenHeight),

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/ScrollBarList.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/ScrollBarList.kt
@@ -3,7 +3,6 @@ package biz.moapp.english_dictionary.ui.top.parts_compose
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -23,10 +22,13 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import biz.moapp.english_dictionary.data.Language
 import biz.moapp.english_dictionary.navigation.Nav
+import com.google.android.gms.ads.AdView
 
 @Composable
 fun ScrollBarList(filterData: List<Language>,
-                  navController: NavController ){
+                  navController: NavController,
+                  banner: AdView
+){
 
     /**LazyColumn の状態を管理**/
     val listState = rememberLazyListState()
@@ -34,7 +36,7 @@ fun ScrollBarList(filterData: List<Language>,
 
     Box(
         modifier = Modifier
-            .fillMaxHeight(0.9f)
+            .fillMaxSize()
             .padding(horizontal = 8.dp)
     ) {
         LazyColumn(
@@ -58,6 +60,8 @@ fun ScrollBarList(filterData: List<Language>,
                 listState = listState,
             )
         }
+        /**バナー広告**/
+        BannerAds(banner)
     }
 }
 

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/ScrollBarList.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/ScrollBarList.kt
@@ -51,9 +51,12 @@ fun ScrollBarList(filterData: List<Language>,
                 }
             }
         }
-        ScrollBar(
-            listState = listState,
-        )
+        /**リスト全件表示の場合、スクロールバー表示（リストの数が最後のアイテムのNumと同じ）**/
+        if(filterData.size == filterData.last().num.toInt()) {
+            ScrollBar(
+                listState = listState,
+            )
+        }
     }
 }
 

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/ScrollBarList.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/ScrollBarList.kt
@@ -3,6 +3,7 @@ package biz.moapp.english_dictionary.ui.top.parts_compose
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -28,40 +29,42 @@ import com.google.android.gms.ads.AdView
 fun ScrollBarList(filterData: List<Language>,
                   navController: NavController,
                   banner: AdView
-){
+) {
 
     /**LazyColumn の状態を管理**/
     val listState = rememberLazyListState()
     val backStackEntry by navController.currentBackStackEntryAsState()
-
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(horizontal = 8.dp)
-    ) {
-        LazyColumn(
-            modifier = Modifier.fillMaxSize().padding(end = 8.dp),
-            state = listState, // 状態を LazyColumn に渡す
-            horizontalAlignment = Alignment.CenterHorizontally
+    BoxWithConstraints {
+        val maxHeight = maxHeight
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 8.dp)
         ) {
-            items(filterData) { data ->
-                ListItem(data) {
-                    navController.navigate("${Nav.SearchResultScreen.name}/${data.englishMean}") {
-                        backStackEntry?.destination?.route?.let {
-                            popUpTo(it) { inclusive = true }
+            LazyColumn(
+                modifier = Modifier.fillMaxSize().padding(end = 8.dp),
+                state = listState, // 状態を LazyColumn に渡す
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                items(filterData) { data ->
+                    ListItem(data) {
+                        navController.navigate("${Nav.SearchResultScreen.name}/${data.englishMean}") {
+                            backStackEntry?.destination?.route?.let {
+                                popUpTo(it) { inclusive = true }
+                            }
                         }
                     }
                 }
             }
+            /**リスト全件表示の場合、スクロールバー表示（リストの数が最後のアイテムのNumと同じ）**/
+            if (filterData.size == filterData.last().num.toInt()) {
+                ScrollBar(
+                    listState = listState,
+                )
+            }
+            /**バナー広告**/
+            BannerAds(banner, maxHeight)
         }
-        /**リスト全件表示の場合、スクロールバー表示（リストの数が最後のアイテムのNumと同じ）**/
-        if(filterData.size == filterData.last().num.toInt()) {
-            ScrollBar(
-                listState = listState,
-            )
-        }
-        /**バナー広告**/
-        BannerAds(banner)
     }
 }
 
@@ -114,4 +117,4 @@ fun BoxScope.ScrollBar(
                 size = Size(scrollBarWidth.toPx(), scrollbarHeight)
             )
         }
-}
+    }

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/ScrollBarList.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/top/parts_compose/ScrollBarList.kt
@@ -3,6 +3,7 @@ package biz.moapp.english_dictionary.ui.top.parts_compose
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -33,7 +34,7 @@ fun ScrollBarList(filterData: List<Language>,
 
     Box(
         modifier = Modifier
-            .fillMaxSize()
+            .fillMaxHeight(0.9f)
             .padding(horizontal = 8.dp)
     ) {
         LazyColumn(


### PR DESCRIPTION
以下対応
1. 初期画面のバナーは下部配置しリストの上に被せるように表示、バナーが被った状態でスクロール可能
2. 絞り込み時の件数が少ない場合のスクロールバーがきれいではないため、絞り込み時はスクロールバー非表示
3. 詳細画面の状態が残らないようにする
4. タブが横に収まりきれてないのでタブを移動した際にタブが動く。固定ではまるようにしたい
> - スクロールせずにタブを画面内に収めて表示可能。
> - TabRowは端末の横幅に合わせて自動調整して表示されている。文字サイズを変えて収まる様に調整。
> - エミュレータで小さい端末（720x1280）で確認してみて問題はなさそうなので一旦、よしとする。