### PR TITLE
語源タブでも英単語を読み上げ可能にする

### DIFF
--- a/app/src/main/java/biz/moapp/english_dictionary/network/RetrofitOpenAiApi.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/network/RetrofitOpenAiApi.kt
@@ -63,7 +63,7 @@ class RetrofitOpenAiNetwork @Inject constructor(moshi: Moshi):OpenAiDataSource{
                         "- English example sentences (10, key name: example)\n" +
                         "- English synonyms (key name: synonym) (key name: word) and their Japanese meanings (key name: mean)\n" +
                         "- English antonyms (key name: antonyms) (key name: word) and their Japanese meanings (key name: mean)\n" +
-                        "- Easy-to-understand explanations of English word origins in Japanese (key name: word_roots)"
+                        "- Easy-to-understand explanations of English word origins in Japanese (key name: word_roots, please surround English words with Japanese quotation marks)"
             ),
         ),
     )

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/SearchResultScreen.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/SearchResultScreen.kt
@@ -154,7 +154,7 @@ fun SearchResultScreen(modifier: Modifier = Modifier, keyWord :String? = "No Key
                                         }
 
                                         4 -> {
-                                            WordRootsTab(data.wordRoots)
+                                            WordRootsTab(data.wordRoots, tts.value)
                                         }
                                     }
                                 }

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/parts_compose/tab_content/WordRootsTab.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/parts_compose/tab_content/WordRootsTab.kt
@@ -1,12 +1,45 @@
 package biz.moapp.english_dictionary.ui.search_result.parts_compose.tab_content
 
-import androidx.compose.foundation.layout.padding
+import android.speech.tts.TextToSpeech
+import android.util.Log
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
+import biz.moapp.english_dictionary.utill.JsonUtil.replaceEnglishWordsWithNumbers
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
-fun WordRootsTab(text:String){
-    Text(text = text, modifier = Modifier.padding(top = 16.dp))
+fun WordRootsTab(text:String,  tts: TextToSpeech?){
+
+    /**文字列文章を英単語ごとにリスト化**/
+    val sentenceList = replaceEnglishWordsWithNumbers(text)
+    Log.d("--check1","$sentenceList")
+
+    /**UI**/
+    FlowRow {
+        sentenceList.forEach { sentence ->
+            Log.d("--check2", sentence)
+            val onClick = remember(tts, sentence) {
+                    { tts?.speak(sentence, TextToSpeech.QUEUE_ADD, null, null) }
+            }
+
+            /**「」で囲まれているのは読み上げ対象のため音声再生アクションの追加**/
+            val clickModifier = if(sentence.contains(Regex("[a-zA-Z]"))){
+                Modifier
+                    .clickable(
+                        onClick = { onClick() },
+                        indication = null,
+                        interactionSource = remember { MutableInteractionSource() },)
+            } else {
+                Modifier
+            }
+
+            Text(text = sentence,modifier = clickModifier)
+        }
+    }
 }

--- a/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/parts_compose/tab_content/WordRootsTab.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/ui/search_result/parts_compose/tab_content/WordRootsTab.kt
@@ -21,7 +21,7 @@ fun WordRootsTab(text:String,  tts: TextToSpeech?){
     Log.d("--check1","$sentenceList")
 
     /**UI**/
-    FlowRow {
+    FlowRow(maxItemsInEachRow = 6) {
         sentenceList.forEach { sentence ->
             Log.d("--check2", sentence)
             val onClick = remember(tts, sentence) {

--- a/app/src/main/java/biz/moapp/english_dictionary/utill/JsonUtil.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/utill/JsonUtil.kt
@@ -41,8 +41,10 @@ object JsonUtil {
     fun replaceEnglishWordsWithNumbers(text: String): List<String> {
         val firstReplaceText = text.replace("「"," 「")
         val endReplaceText = firstReplaceText.replace("」","」 ")
-        val sentenceList = endReplaceText.split(" ")
-        Log.d("--sentenceList","${sentenceList}")
+        val periodReplaceText = endReplaceText.replace("。","。 ")
+        val punctuationReplaceText = periodReplaceText.replace("、","、 ")
+        val sentenceList = punctuationReplaceText.split(" ")
+        Log.d("--sentenceList","$sentenceList")
         return sentenceList
     }
 }

--- a/app/src/main/java/biz/moapp/english_dictionary/utill/JsonUtil.kt
+++ b/app/src/main/java/biz/moapp/english_dictionary/utill/JsonUtil.kt
@@ -36,4 +36,13 @@ object JsonUtil {
             listOf(japaneseMeaning)
         }
     }
+
+    /**文字列の文章を「」に囲われている英単語ごとにセンテンスを区切り、リスト化**/
+    fun replaceEnglishWordsWithNumbers(text: String): List<String> {
+        val firstReplaceText = text.replace("「"," 「")
+        val endReplaceText = firstReplaceText.replace("」","」 ")
+        val sentenceList = endReplaceText.split(" ")
+        Log.d("--sentenceList","${sentenceList}")
+        return sentenceList
+    }
 }


### PR DESCRIPTION
語源タブ上での英単語の発音読み上げの実装。

1. 全て１つの文字列で受け取っていたものを「」に囲まれた英単語、句読点ごとにsplitして文章をリスト化
2. FlowRowで囲みリストをループしてText()でUIに反映していく
3. 英単語だったら音声アクションをTextのModifierにつける